### PR TITLE
Add react-component keyword to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "keywords": [
     "placeholder",
     "input",
-    "react"
+    "react",
+    "react-component"
   ],
   "author": "enigma.io",
   "license": "MIT",


### PR DESCRIPTION
This is a recommended convention right now to make react components discoverable.
