### PR TITLE
Use existing type if provided

### DIFF
--- a/src/react-input-placeholder.js
+++ b/src/react-input-placeholder.js
@@ -94,7 +94,7 @@ var createShimmedElement = function(React, elementConstructor, name) {
         if (!value) {
           this.isPlaceholding = true;
           value = this.props.placeholder;
-          element.props.type = 'text';
+          element.props.type = this.props.type || 'text';
           element.props.className += ' placeholder';
         } else {
           this.isPlaceholding = false;


### PR DESCRIPTION
Instead of forcing a type of 'text', use existing type if available.