### PR TITLE
Check for document before using it.

### DIFF
--- a/src/react-input-placeholder.js
+++ b/src/react-input-placeholder.js
@@ -1,4 +1,4 @@
-var isPlaceholderSupported = 'placeholder' in document.createElement('input');
+var isPlaceholderSupported = (typeof document !== 'undefined') && 'placeholder' in document.createElement('input');
 
 /**
  * Input is a wrapper around React.DOM.input with a `placeholder` shim for IE9.


### PR DESCRIPTION
This module was crashing on the server because there was no `window` or `document`.