### PR TITLE
Remove type property

### DIFF
--- a/src/react-input-placeholder.js
+++ b/src/react-input-placeholder.js
@@ -125,7 +125,6 @@ var createShimmedElement = function(React, elementConstructor, name) {
                 if (!value) {
                     this.isPlaceholding = true;
                     value = this.props.placeholder;
-                    element.props.type = 'text';
                     element.props.className += ' placeholder';
                 } else {
                     this.isPlaceholding = false;


### PR DESCRIPTION
 * type="text" is an invalid value for textarea
 * property should be given from outside similar to normal <input /> element

Caused 

`cannot set property type of [object Object] which has only a getter` error with jsdom