### PR TITLE
Remove React.createFactory call on new React versions since React thr…

### DIFF
--- a/src/react-input-placeholder.js
+++ b/src/react-input-placeholder.js
@@ -147,8 +147,8 @@ module.exports = function(React) {
         };
     } else { /* -- end */
         return {
-            Input: React.createFactory(createShimmedElement(React, 'input', 'Input')),
-            Textarea: React.createFactory(createShimmedElement(React, 'textarea', 'Textarea'))
+            Input: createShimmedElement(React, 'input', 'Input'),
+            Textarea: createShimmedElement(React, 'textarea', 'Textarea')
         };
     }
 };


### PR DESCRIPTION
…ows warning about no render method defined when component is wrapped with createFactory

Warning: Component(...): No `render` method found on the returned component instance: you may have forgotten to define `render` in your component or you may have accidentally tried to render an element whose type is a function that isn't a React component.